### PR TITLE
Remove repo specific CoC.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Community Code of Conduct
-
-Contributors to the Make WordPress Community Team are asked to abide by the [Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).


### PR DESCRIPTION
## Summary
This removes the repository specific `CODE_OF_CONDUCT.md` file in favor of the newly added version maintained as the organization's default within the WordPress/.github repository.

While this file will not be included in `git clone`s, it will be displayed on the repository's main page and anywhere else GitHub includes a Code of Conduct link.

This change enables more consistent messaging for the community code of conduct, and allows the file to be updated in one location for all repositories under the WordPress organization.

See https://github.com/WordPress/.github/pull/1.